### PR TITLE
site name change on MaxCDN (formerly known as NetDNA)

### DIFF
--- a/lib/fontawesome-rails-cdn/action_view_helpers.rb
+++ b/lib/fontawesome-rails-cdn/action_view_helpers.rb
@@ -1,7 +1,7 @@
 module FontAwesome::Rails::CDN
   module ActionViewExtensions
     OFFLINE = ( ::Rails.env.development? )
-    DEFAULT_HOST = :netdna
+    DEFAULT_HOST = :maxcdn
     FONTAWESOME_VERSIONS = [ '4.0.3', '3.2.1' ]
 
     def fontawesome_stylesheet_url(host = DEFAULT_HOST, options = {})
@@ -24,10 +24,13 @@ module FontAwesome::Rails::CDN
     def fontawesome_cdn_url(host, options = {})
       version  = options[:version] || FONTAWESOME_VERSIONS.first
 
-      {
-        :netdna => "//netdna.bootstrapcdn.com/font-awesome/#{version}/css/font-awesome.min.css",
+      urls = {
+        :maxcdn -> "//maxcdn.bootstrapcdn.com/font-awesome/#{version}/css/font-awesome.min.css",
         :local  => "font-awesome-#{version}.min.css"
-      }[host]
+      }
+      # for older compatibility
+      urls[:netdna] = urls[:maxcdn]
+      urls[host]
     end
   end
 end


### PR DESCRIPTION
The service name and domain NetDNA is renamed to MaxCDN. URLs also changed (old ones are still available, though).

For backward compatibility, `:netdna` is kept as an alias of `:maxcdn`.
